### PR TITLE
Run Pico build action on PRs too

### DIFF
--- a/.github/workflows/pico-build.yml
+++ b/.github/workflows/pico-build.yml
@@ -1,6 +1,6 @@
 name: CMake
 
-on: [push]
+on: [push, pull_request]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)


### PR DESCRIPTION
If they're from external contributors (and hence not a push event on a repo branch) you still want to see if they worked, it will also give you/them a file to test with still.

Clearly later steps to publish to e.g. gh-pages wouldn't want to run for PRs.